### PR TITLE
Don't automatically add username and password to the DSN.

### DIFF
--- a/src/Ccovey/ODBCDriver/ODBCDriverConnector.php
+++ b/src/Ccovey/ODBCDriver/ODBCDriverConnector.php
@@ -21,7 +21,7 @@ class ODBCDriverConnector extends Connector implements ConnectorInterface
 	protected function getDsn(array $config) {
         extract($config);
 
-        $dsn = "odbc:{$dsn}; {$username}; {$password};";
+        $dsn = "odbc:{$dsn}";
 
         return $dsn;
     }


### PR DESCRIPTION
Specifying username and password in this format in the DSN might not be supported by all databases (didn't work for me with Pervasive/unixODBC). Users can still add username and password to the DSN manually in the database config if needed.
