### PR TITLE
Fixed grammars naming inconsistency.

### DIFF
--- a/src/Ccovey/ODBCDriver/Grammars/DB2Grammar.php
+++ b/src/Ccovey/ODBCDriver/Grammars/DB2Grammar.php
@@ -5,7 +5,7 @@ use Illuminate\Database\Query\Grammars\Grammar;
 /**
 * DB2 Grammar
 */
-class DB2 extends Grammar
+class DB2Grammar extends Grammar
 {
      /**
      * Compile the "limit" portions of the query.

--- a/src/Ccovey/ODBCDriver/ODBCDriverConnection.php
+++ b/src/Ccovey/ODBCDriver/ODBCDriverConnection.php
@@ -13,12 +13,12 @@ class ODBCDriverConnection extends Connection
 		$grammarConfig = $this->getGrammarConfig();
 
 		if ($grammarConfig) {
-			$packageGrammar = "Ccovey\\ODBCDriver\\Grammars\\" . $grammarConfig; 
+			$packageGrammar = "Ccovey\\ODBCDriver\\Grammars\\" . $grammarConfig . "Grammar";
 			if (class_exists($packageGrammar)) {
 				return $this->withTablePrefix(new $packageGrammar);
 			}
 			
-			$illuminateGrammar = "Illuminate\\Database\\Query\\Grammars\\" . $grammarConfig;
+			$illuminateGrammar = "Illuminate\\Database\\Query\\Grammars\\" . $grammarConfig . "Grammar";
 			if (class_exists($illuminateGrammar)) {
 				return $this->withTablePrefix(new $illuminateGrammar);
 			}


### PR DESCRIPTION
Default grammars included in Laravel all include the "Grammar" suffix, this patch automatically appends "Grammar" to the grammar name set by user in the database config, so you can use short more consistent names like "DB2" and "MySql", instead of "DB2" and "MySqlGrammar".
