### PR TITLE
Allowed use of 4.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,8 +9,8 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "illuminate/support": "4.1.x",
-        "illuminate/database": "4.1.x",
+        "illuminate/support": ">=4.1",
+        "illuminate/database": ">=4.1",
         "ext-pdo_odbc": "*"
     },
     "require-dev": {


### PR DESCRIPTION
You can't use your odbc driver with later versions of laravel
